### PR TITLE
use `os.tmpdir()` polyfill for more consistent behaviour

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var os = require('os')
+var osTmpdir = require('os-tmpdir')
 var path = require('path')
 var cuid = require('cuid')
 var mkdirp = require('mkdirp')
@@ -10,7 +10,7 @@ module.exports = function tmpdir (title, cb) {
     title = 'tmp'
   }
 
-  var tmp = path.join(os.tmpdir(), title + '-' + cuid())
+  var tmp = path.join(osTmpdir(), title + '-' + cuid())
   mkdirp(tmp, function (err) {
     if (err) return cb(err)
     cb(null, tmp, cleanup)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "cuid": "^1.2.5",
     "mkdirp": "^0.5.1",
+    "os-tmpdir": "^1.0.1",
     "rimraf": "^2.3.3",
     "standard": "^3.9.0"
   }


### PR DESCRIPTION
The `os.tmpdir()` method has changed a lot between Node versions. This gives you a stable and consistent result for all node versions.

Node 0.10.38: https://github.com/joyent/node/blob/0b5731a63cc40c4fe9275c79158fe0a5dd4d1609/lib/os.js#L44-L49

io.js 2.0.2: https://github.com/nodejs/io.js/blob/c7fb91dc1310f9454d4aa8091bcc6d305322a72f/lib/os.js#L25-L43

From io.js changelog:

> os.tmpdir() is now cross-platform consistent and will no longer returns a path with a trailling slash on any platform
> 
> Updated os.tmpdir on Windows to use the %SystemRoot% or %WINDIR% environment variables instead of the hard-coded value of c:\windows when determining the temporary directory location.

---

https://github.com/sindresorhus/os-tmpdir
